### PR TITLE
Rocket reserve and cancel

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,10 +1,16 @@
-import React from 'react';
+import { React, useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import { Routes, Route } from 'react-router-dom';
 import Rockets from './components/Rockets';
 import Missions from './components/Missions/Missions';
 import Profile from './components/Profile';
+import { fetchRockets } from './Redux/rockets/rocketsReducer';
 
 function App() {
+  const dispatch = useDispatch();
+  useEffect(() => {
+    dispatch(fetchRockets());
+  }, []);
   return (
     <Routes>
       <Route exact path="/" element={<Rockets />} />

--- a/src/Redux/rockets/rocketsReducer.js
+++ b/src/Redux/rockets/rocketsReducer.js
@@ -18,6 +18,11 @@ const rocketsSlice = createSlice({
       );
       rocket.reserved = true;
     },
+    // booking cancellation reducer
+    cancelReserve: (state, action) => {
+      const rocket = state.rockets.find((rocket) => rocket.rocket_id === action.payload);
+      rocket.reserved = false;
+    },
   },
 });
 
@@ -26,6 +31,7 @@ export default rocketsSlice.reducer;
 export const {
   rocketsSuccess,
   reserveRocket,
+  cancelReserve,
   rocketsErr,
 } = rocketsSlice.actions;
 

--- a/src/components/Rocket.js
+++ b/src/components/Rocket.js
@@ -1,10 +1,14 @@
 /* eslint-disable camelcase */
+
 import React from 'react';
 import PropTypes from 'prop-types';
+import { useDispatch } from 'react-redux';
+import { reserveRocket, cancelReserve } from '../Redux/rockets/rocketsReducer';
 
 const Rockets = ({ rocket }) => {
+  const dispatch = useDispatch();
   const {
-    rocket_name, description, flickr_images, reserved,
+    rocket_id, rocket_name, description, flickr_images, reserved,
   } = rocket;
 
   return (
@@ -24,6 +28,8 @@ const Rockets = ({ rocket }) => {
           <button
             type="button"
             className={reserved === true ? 'disabled button' : 'reserve-btn button'}
+            onClick={() => (!reserved ? dispatch(reserveRocket(rocket_id))
+              : dispatch(cancelReserve(rocket_id)))}
           >
             {reserved ? 'Cancel Reservation' : 'Reserve Rocket'}
           </button>

--- a/src/index.css
+++ b/src/index.css
@@ -92,3 +92,10 @@ button:hover {
 .rocket-desc {
   line-height: 30px;
 }
+
+.status {
+  padding: 1px;
+  width: auto;
+  color: #fff;
+  border-radius: 5%;
+}


### PR DESCRIPTION
### In this project PR,  I  Implemented the following:
**Reserve Rocket**
- When a user clicks the "Reserve rocket" button,  I dispatched an action to update the store by setting setting the reserved key to ```true```
- used the  ID of the reserved rocket and update the state.
- Maintained immutable state. 
- On the ```reserve rocket``` button ```click```, reserved with its value set to true. new state - i.e.:
- Placed the  reserve rocket logic in the reducer.

> [[3pt] Implement rocket booking - Actions #12](https://github.com/mwenyoa/space-travelers-react/issues/12).

**Cancel Rocket Reservation**
- Followed the same logic as with the "Reserve rocket" - but set the ```reserved key to false```.
> [[1pt] Implement rocket booking cancelation - Actions #8](https://github.com/mwenyoa/space-travelers-react/issues/8)