### PR TITLE
Rocket switch badges

### DIFF
--- a/src/components/Rocket.js
+++ b/src/components/Rocket.js
@@ -27,7 +27,7 @@ const Rockets = ({ rocket }) => {
         <div>
           <button
             type="button"
-            className={reserved === true ? 'disabled button' : 'reserve-btn button'}
+            className={reserved === true ? 'disabled' : 'reserve-btn button'}
             onClick={() => (!reserved ? dispatch(reserveRocket(rocket_id))
               : dispatch(cancelReserve(rocket_id)))}
           >

--- a/src/index.css
+++ b/src/index.css
@@ -94,8 +94,20 @@ button:hover {
 }
 
 .status {
-  padding: 1px;
+  padding: 2px 4px;
+  background-color: rgb(60, 140, 177);
   width: auto;
   color: #fff;
   border-radius: 5%;
+  margin-right: 1rem;
+}
+
+.disabled {
+  padding: 8px;
+  background-color: rgb(222, 232, 236);
+  color: rgb(83, 78, 78);
+  font-size: large;
+  margin-top: 10px;
+  border-radius: 5px;
+  border-color: rgb(222, 232, 236);
 }


### PR DESCRIPTION
### In this PR, I:
- Implemented the feature to make sure that, Rockets that have already been reserved should show a ```Reserved``` badge and ```Cancel reservation``` button instead of the default ```Reserve rocket``` (as per design)
- Used the React conditional rendering syntax:
>[[1pt] Switch badges for Rockets - Conditional components #5](https://github.com/mwenyoa/space-travelers-react/issues/5)